### PR TITLE
Fixed rspec with overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -25,10 +25,6 @@ PreCommit:
     exclude:
       - '/db/**/*' # Ignore trailing whitespace in generated files
 
-  Rspec:
-    enabled: true
-    command: ['bundle', 'exec', 'rspec']
-    on_warn: fail
 
 #PostCheckout:
 #  ALL: # Special hook name that customizes all hooks of this type
@@ -41,3 +37,14 @@ PrePush:
     enabled: true
     command: ['bundle', 'exec', 'brakeman']
     on_warn: fail
+
+  RakeTarget:
+    enabled: true
+    description: 'Run rake tasks'
+    targets:
+      - 'db:prepare'
+      - 'spec'
+    command: ['bundle', 'exec', 'rake']
+
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,4 @@ group :development, :test do
   gem 'capybara', '~> 3.40.0'
   gem 'database_cleaner', '~> 2.0.2'
   gem 'faker', '~> 3.2.3'
-
 end

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,12 @@ ENV['RACK_ENV'] ||= 'development'
 
 require_relative './config/environment'
 require 'sinatra/activerecord/rake'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+desc 'Run all tests, even those usually excluded.'
+task all_tests: :environment do
+  ENV['RUN_ALL_TESTS'] = 'true'
+  Rake::Task['spec'].invoke
+end

--- a/spec/application_controller_spec.rb
+++ b/spec/application_controller_spec.rb
@@ -1,13 +1,15 @@
-require_relative "spec_helper"
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
 
 def app
   ApplicationController
 end
 
 describe ApplicationController do
-  it "responds with a welcome message" do
+  it 'responds with a welcome message' do
     get '/'
     expect(last_response.status).to eq(200)
-    expect(last_response.body).to include("Hello World!")
+    expect(last_response.body).to include('Hello World!')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-ENV["RACK_ENV"] = "test"
+# frozen_string_literal: true
+
+ENV['RACK_ENV'] = 'test'
 
 require_relative '../config/environment'
 require 'rack/test'


### PR DESCRIPTION
Overcommit runs rspec as a pre-push-hook. Rspec needs a working test-database. This commit moves rspec in overcommit to pre-push and adds a rake-task for rspec. It also creates a empty db/seeds.db file so that `rake db:prepare` works. Before overcommit runs 'rspec' it first executes `rake db:prepare`.

Also, this commit fixes some rubocop-issues