### PR TITLE
Feature reveal ajax

### DIFF
--- a/app/views/show.erb
+++ b/app/views/show.erb
@@ -3,7 +3,6 @@
 <div id="bin-content">
   <h1>Your Secret:</h1>
   <span id="bin-id" class="hidden"><%= @bin.id %></span>
-  <span id="enc-key" class="hidden"><%= @bin.payload %></span>
   <textarea id="dec-msg" readonly rows="20" cols="40"></textarea>
 </div>
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -2,6 +2,13 @@
 default: &common_settings
   cleanup_schedule: "5m"
 
+production:
+  <<: *common_settings
+
+development:
+  <<: *common_settings
+  cleanup_schedule: "2s"
+
 test:
   <<: *common_settings
   cleanup_schedule: "2s"

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -1,10 +1,10 @@
 
-function reveal() {
+async function reveal() {
   const element = document.getElementById("reveal-content");
   element.remove();
   const element2 = document.getElementById("bin-content");
   element2.style.display = "block";
-  decryptEvent();
+  await fetchEncrypted();
 }
 
 function copyToClip(){

--- a/public/javascripts/decrypt.js
+++ b/public/javascripts/decrypt.js
@@ -35,10 +35,28 @@ async function decryptMessage(key, ciphertext, iv) {
   return dec.decode(decrypted);
 }
 
-async function decryptEvent() {
+async function fetchEncrypted() {
+  let binid = document.getElementById('bin-id').innerText;
+
+  await fetch("/bins/" + binid + "/reveal", {
+    method: 'PATCH',
+    headers: {
+       'Content-type': 'application/json; charset=UTF-8',
+    },
+  }).then((response) => {
+    return response.json()
+  }).then((res) => {
+    decryptEvent(res.payload);
+  }).catch((error) => {
+    console.log(error)
+  });
+
+}
+
+async function decryptEvent(payload) {
   const keyiv = getKeyFromUrl();
   const key = await getKeyfromB64(keyiv[0]);
   const iv = base64ToBytes(keyiv[1]);
-  const message = document.getElementById('enc-key').innerText;
+  const message = payload;
   document.getElementById('dec-msg').value= await decryptMessage(key, base64ToBytes(message), iv);
 }

--- a/spec/application_controller_spec.rb
+++ b/spec/application_controller_spec.rb
@@ -56,7 +56,7 @@ describe ApplicationController do
     bin = Bin.create(payload: 'Hello, World!')
     get "/bins/#{bin.id}"
     expect(last_response.status).to eq(200)
-    expect(last_response.body).to include('Hello, World!')
+    expect(last_response.body).to include("#{bin.id}")
   end
 
   it 'returns 404 if bin does not exist' do


### PR DESCRIPTION
This PR removes the payload from the "reveal"-page. Only if the user pushes the reveal-button, the payload gets fetched using an ajax call and deleted from the database.