### PR TITLE
Improve Dockerfile

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           bundle exec rake db:create
           bundle exec rake db:migrate
-          sqlite3 db/test.sqlite3 "select * from schema_migrations"
+          sqlite3 db/database/test.sqlite3 "select * from schema_migrations"
       - name: Run brakeman
         run: bundle exec brakeman
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /test/version_tmp/
 /tmp/
 db/*.sqlite*
+db/database/*.sqlite*
+
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,4 @@ COPY . .
 
 RUN bundle install
 
-RUN bundle exec rake db:migrate
-CMD ["bundle","exec","rerun","--","rackup","-o","0.0.0.0"]
+CMD ["bundle","exec","rake","migrateserv"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ bundle exec rerun rackup
 bin/console
 ```
 
+## Docker
+
+### Build Container
+
+```
+docker build -t aha-secret .
+```
+
+### Run Application
+
+*Please note that the following command will not persist any data and stored secrets will be deleted if the container is stopped*
+
+```
+docker run --rm -it aha-secret
+```
+
 ## run specs
 
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -35,3 +35,9 @@ desc 'Cleanup expired bins.'
 task cleanup: :environment do
   Bin.cleanup
 end
+
+desc 'Prepare db and serve.'
+task :migrateserv do
+  Rake::Task['db:migrate'].invoke
+  Rake::Task['serve'].invoke
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -2,6 +2,9 @@
 default: &common_settings
   cleanup_schedule: "5m"
 
+production:
+  <<: *common_settings
+
 test:
   <<: *common_settings
   cleanup_schedule: "2s"

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,13 @@
+---
 # activerecord database configuration
 development:
   adapter: sqlite3
-  database: db/development.sqlite3
+  database: db/database/development.sqlite3
 
 test:
   adapter: sqlite3
-  database: db/test.sqlite3
+  database: db/database/test.sqlite3
 
 production:
   adapter: sqlite3
-  database: db/production.sqlite3
+  database: db/database/production.sqlite3


### PR DESCRIPTION
This commit adds a rake task for "db:migrate and serve". If this application is run inside a container, it will create the database during the execution and not during building the container. This allows to add volumes for persisting the database.

This PR fixes #38
