### PR TITLE
Add development section in config

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -5,3 +5,6 @@ default: &common_settings
 test:
   <<: *common_settings
   cleanup_schedule: "2s"
+
+development:
+  <<: *common_settings


### PR DESCRIPTION
Rufus could not find `settings.cleanup_schedule`.