### PR TITLE
Make base64-keymaterial urlsafe

### DIFF
--- a/public/javascripts/decrypt.js
+++ b/public/javascripts/decrypt.js
@@ -1,7 +1,11 @@
 function getKeyFromUrl(){
   const hash = window.location.hash;
   const key = hash.match(/^[^#]*#(.*)/)[1];
-  return key.split('&');
+  let keyv = key.split('&');
+  /* replace urlsafe b64, with normal b64 */
+  keyv[0] = keyv[0].replace(/-/g, '+').replace(/_/g, '/');
+  keyv[1] = keyv[1].replace(/-/g, '+').replace(/_/g, '/');
+  return keyv;
 }
 
 function base64ToBytes(base64) {

--- a/public/javascripts/encrypt.js
+++ b/public/javascripts/encrypt.js
@@ -67,8 +67,9 @@ async function encryptMessage(key) {
 }
 
 function createLink(id) {
-  const b64Key = document.getElementById('enc-key').innerText;
-  const b64Iv = document.getElementById('enc-iv').innerText;
+  /* replace normal b64, with urlsafe b64 */
+  const b64Key = document.getElementById('enc-key').innerText.replace(/\+/g, '-').replace(/\//g, '_');
+  const b64Iv = document.getElementById('enc-iv').innerText.replace(/\+/g, '-').replace(/\//g, '_');
   const url = window.location.href + "bins/" + id + '#' + b64Key + '&' + b64Iv;
   document.getElementById("secret-url").value = url;
 }

--- a/public/javascripts/encrypt.js
+++ b/public/javascripts/encrypt.js
@@ -67,7 +67,7 @@ async function encryptMessage(key) {
 }
 
 function createLink(id) {
-  /* replace normal b64, with urlsafe b64 */
+  /* replace normal b64, with urlsafe b64. we keep the '=' */
   const b64Key = document.getElementById('enc-key').innerText.replace(/\+/g, '-').replace(/\//g, '_');
   const b64Iv = document.getElementById('enc-iv').innerText.replace(/\+/g, '-').replace(/\//g, '_');
   const url = window.location.href + "bins/" + id + '#' + b64Key + '&' + b64Iv;


### PR DESCRIPTION
The key and the initial-vector gets encoded to base64. Normal base64 is not urlsafe. This PR replaces '+' by '-' and '/' by '_' . For the moment I let the '=' sign. We could remove it and add it again when putting it together. But I would suggest to see if the '=' turns out to be a problem since it is just a "reserved character" for urls.

This PR fixes #76 