### PR TITLE
Add default rake task (running tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ docker run --rm -it aha-secret
 ```
 RACK_ENV=test bundle exec rake db:migrate
 bundle exec rspec
+# OR
+bundle exec rake
 ```
 
 ## Environment variables

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ require_relative 'config/environment'
 require 'sinatra/activerecord/rake'
 require 'rspec/core/rake_task'
 
+task default: :spec
+
 desc 'Starts the thin web server through rackup.'
 task :serve do
   `bundle exec rackup -p 9292`


### PR DESCRIPTION
Now you can call 

```
bundle exec rake
```

which seems more standard than running

```
bundle exec rspec
```