### PR TITLE
Add exception handler for debugging to decrypt-js

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_07_035007) do
+ActiveRecord::Schema[7.2].define(version: 2024_04_07_035007) do
   create_table "bins", id: false, force: :cascade do |t|
     t.text "payload"
     t.datetime "created_at", null: false
@@ -19,5 +19,4 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_07_035007) do
     t.datetime "expire_date", default: -> { "datetime('now','+7 day','localtime')" }
     t.index ["id"], name: "index_bins_on_id", unique: true
   end
-
 end

--- a/public/javascripts/decrypt.js
+++ b/public/javascripts/decrypt.js
@@ -9,13 +9,17 @@ function getKeyFromUrl(){
 }
 
 function base64ToBytes(base64) {
-  let binary_string =  window.atob(base64);
-  let len = binary_string.length;
-  let bytes = new Uint8Array(len);
-  for (var i = 0; i < len; i++) {
-    bytes[i] = binary_string.charCodeAt(i);
+  try{
+	let binary_string =  window.atob(base64);
+        let len = binary_string.length;
+        let bytes = new Uint8Array(len);
+        for (var i = 0; i < len; i++) {
+          bytes[i] = binary_string.charCodeAt(i);
+        }
+        return bytes;
+  } catch(err) {
+	console.log(err);
   }
-  return bytes;
 }
 
 async function getKeyfromB64(base64key) {
@@ -60,8 +64,12 @@ async function fetchEncrypted() {
 
 async function decryptEvent(payload) {
   const keyiv = getKeyFromUrl();
-  const key = await getKeyfromB64(keyiv[0]);
-  const iv = base64ToBytes(keyiv[1]);
-  const message = payload;
-  document.getElementById('dec-msg').value= await decryptMessage(key, base64ToBytes(message), iv);
+  try{
+        const key = await getKeyfromB64(keyiv[0]);
+        const iv = base64ToBytes(keyiv[1]);
+        const message = payload;
+        document.getElementById('dec-msg').value= await decryptMessage(key, base64ToBytes(message), iv);
+  } catch(err) {
+	console.log(err);
+  }
 }


### PR DESCRIPTION
This PR adds an exception handler for debugging to decrypt.js. When an error occurs, it will be displayed in the console.