### PR TITLE
process defined params only

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 require './config/environment'
 require 'rufus-scheduler'
+require_relative '../helpers/helpers'
 
 # write documentation
 class ApplicationController < Sinatra::Base
@@ -34,9 +35,10 @@ class ApplicationController < Sinatra::Base
 
   # This will be a ajax call
   post '/' do
-    bin = Bin.new(params[:bin])
+    reduced_params = reduce_params(params)
+    bin = Bin.new(reduced_params[:bin])
 
-    retention_minutes = params[:retention]&.to_i&.minutes
+    retention_minutes = reduced_params[:retention]&.to_i&.minutes
     if retention_minutes&.positive?
       bin.expire_date = Time.now + retention_minutes
       params.delete(:retention)
@@ -70,8 +72,6 @@ class ApplicationController < Sinatra::Base
   end
 
   helpers do
-    def bin_retrieval_url(bin)
-      "#{request.base_url}/bins/#{bin.id}"
-    end
+    include Helpers
   end
 end

--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Application Controller helper methods
+module Helpers
+  def bin_retrieval_url(bin)
+    "#{request.base_url}/bins/#{bin.id}"
+  end
+
+  # strip params to only: payload (text), password (boolean) and retention (integer)
+  def reduce_params(params)
+    # check bin's params
+    params = reduce_bin_params(params[:bin]) if params[:bin]
+
+    # check retention - which is given in seconds and converted to DateTime later
+    params.delete(:retention) unless params[:retention]&.to_i&.positive?
+    # check top level keys
+    params.each_key do |key|
+      params.delete(key) unless %w[bin retention].include?(key.to_s)
+    end
+    params
+  end
+
+  def reduce_bin_params(params)
+    # check bin's params
+    params.each_key do |key|
+      params.delete(key) unless %w[payload password].include?(key.to_s)
+    end
+    params
+  end
+end

--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -9,7 +9,7 @@ module Helpers
   # strip params to only: payload (text), password (boolean) and retention (integer)
   def reduce_params(params)
     # check bin's params
-    params = reduce_bin_params(params[:bin]) if params[:bin]
+    params[:bin] = reduce_bin_params(params[:bin]) if params[:bin]
 
     # check retention - which is given in seconds and converted to DateTime later
     params.delete(:retention) unless params[:retention]&.to_i&.positive?

--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -6,7 +6,7 @@ module Helpers
     "#{request.base_url}/bins/#{bin.id}"
   end
 
-  # strip params to only: payload (text), password (boolean) and retention (integer)
+  # strip params to only: payload (text), has_password (boolean) and retention (integer)
   def reduce_params(params)
     # check bin's params
     params[:bin] = reduce_bin_params(params[:bin]) if params[:bin]
@@ -23,7 +23,7 @@ module Helpers
   def reduce_bin_params(params)
     # check bin's params
     params.each_key do |key|
-      params.delete(key) unless %w[payload password].include?(key.to_s)
+      params.delete(key) unless %w[payload has_password].include?(key.to_s)
     end
     params
   end

--- a/spec/application_controller_spec.rb
+++ b/spec/application_controller_spec.rb
@@ -85,9 +85,9 @@ describe ApplicationController do
 
   # helper methods
   it 'reduces params to only payload, password and retention' do
-    params = Sinatra::IndifferentHash.new.merge!(bin: { payload: 'Hello', password: 'true', some: 'value', foo: 'bar' }, retention: '10080', other: 'value')
+    params = Sinatra::IndifferentHash.new.merge!(bin: { payload: 'Hello', has_password: 'true', some: 'value', foo: 'bar' }, retention: '10080', other: 'value')
     reduced_params = app.helpers.reduce_params(params)
-    expected_params = Sinatra::IndifferentHash.new.merge!(bin: { payload: 'Hello', password: 'true' }, retention: '10080' )
+    expected_params = Sinatra::IndifferentHash.new.merge!(bin: { payload: 'Hello', has_password: 'true' }, retention: '10080' )
     expect(reduced_params).to eq(expected_params)
   end
 end


### PR DESCRIPTION
This pr adds functionality to check the params of "create bin" POST request.

First level: Other params than `params[:bin]` and `params[:retention_time]` are removed.
"bin" level: Other params than `params[:bin][:payload]` and `params[:bin][:has_password]` 

I refactored the controllers helper methods into a helpers file (for easier testing).