### PR TITLE
Do not expose memcache port to all interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
 
   memcached:
     image: "memcached:latest"
-    ports:
-      - "11211:11211"
 
 volumes:
   ahadb:


### PR DESCRIPTION
Memcache is only needed locally. So it is not necessary to expose the port in the docker-compose-file to all interfaces