### PR TITLE
Add option to append or replace html title, meta description and meta keywords

### DIFF
--- a/app/helpers/helpers.rb
+++ b/app/helpers/helpers.rb
@@ -13,4 +13,31 @@ module Helpers
   def l(*)
     I18n.l(*)
   end
+
+  def html_title(custom:, content:)
+    default_content = 'aha-secret: Share Secrets'
+    return default_content unless custom
+
+    return content if custom == 'replace'
+
+    "#{content} | #{default_content}"
+  end
+
+  def html_meta_description(custom:, content:)
+    default_content = 'AHA-Secret is a simple and secure way to share secrets.'
+    return default_content unless custom
+
+    return content if custom == 'replace'
+
+    "#{content}, #{default_content}"
+  end
+
+  def html_meta_keywords(custom:, content:)
+    default_content = 'secret, share, encryption, secure, simple, bin, paste, text, code'
+    return default_content unless custom
+
+    return content if custom == 'replace'
+
+    "#{content}, #{default_content}"
+  end
 end

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -3,13 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no,maximum-scale=1.0,user-scalable=no">
-    <meta name="description" content="Share secrets securely">
+    <meta name="description" content="<%= html_meta_description(custom: settings.custom.dig(:meta_description), content: settings.custom.dig(:meta_description_string)) %> ">
+    <meta name="keywords" content="<%= html_meta_keywords(custom: settings.custom.dig(:meta_keywords), content: settings.custom.dig(:meta_keywords_string)) %> ">
     <meta name="author" content="aha-oida">
     <meta name="authenticity_token" content="<%= @authenticity_token %>">
 
-    <title>aha-secret: Share Secrets</title>
+    <title><%= html_title(custom:settings.custom['html_title'], content: settings.custom['html_title_string']) %></title>
     <link rel="stylesheet" type="text/css" href="<%= stylesheet_path 'application' %>" />
-    <% if settings.custom_stylesheet %>
+    <% if settings.custom[:stylesheet] %>
       <link rel="stylesheet" type="text/css" href="<%= stylesheet_path 'custom' %>" />
     <% end %>
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,6 +4,13 @@ default: &common_settings
   url: "/"
   default_locale: "en"
   custom_stylesheet: false # set to true to use custom stylesheet in public/stylesheets/custom.css
+  custom:
+    stylesheet: true # set to true to use custom stylesheet in public/stylesheets/custom.css
+    html_title: append # possible values: false, replace, append
+    html_title_string: your-custom-title-here
+    meta_description: replace # possible values: false, replace, append
+    meta_description_string: your-custom-description-here
+    meta_description_keywords: your, keywords, here
 
 production:
   <<: *common_settings

--- a/config/config.yml
+++ b/config/config.yml
@@ -3,7 +3,6 @@ default: &common_settings
   cleanup_schedule: "5m"
   url: "/"
   default_locale: "en"
-  custom_stylesheet: false # set to true to use custom stylesheet in public/stylesheets/custom.css
   custom:
     stylesheet: true # set to true to use custom stylesheet in public/stylesheets/custom.css
     html_title: append # possible values: false, replace, append
@@ -23,3 +22,10 @@ test:
   <<: *common_settings
   # TODO: not needed anymore because we do not use rufus in tests?
   cleanup_schedule: "2s"
+  custom:
+    stylesheet: false
+    html_title: false # possible values: false, replace, append
+    html_title_string: custom-title
+    meta_description: false # possible values: false, replace, append
+    meta_description_string: custom-meta-description
+    meta_description_keywords: custom, meta, description

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+include Helpers
+
+RSpec.describe Helpers, type: :helper do
+  describe '#bin_retrieval_url' do
+    let(:request) { double('request', base_url: 'http://example.org') }
+
+    it 'returns the bin retrieval url' do
+      bin = Bin.new(payload: 'Hello, World!')
+      expect(bin_retrieval_url(bin)).to eq("http://example.org/bins/#{bin.id}")
+    end
+  end
+
+  describe '#html_title' do
+    # let(:config) { double('config', custom: { title: 'Secret Bin' }) }
+
+    it 'returns the default title' do
+      expect(html_title(custom:false, content:nil)).to eq('aha-secret: Share Secrets')
+    end
+
+    it 'returns the custom title' do
+      expect(html_title(custom:'replace', content:'Custom Title')).to eq('Custom Title')
+    end
+
+    it 'returns the custom title appended to the default title' do
+      expect(html_title(custom:'append', content:'Custom Title')).to eq('Custom Title | aha-secret: Share Secrets')
+    end
+  end
+
+  describe '#html_meta' do
+    it 'returns the default meta description' do
+      expect(html_meta_description(custom:false, content:nil)).to eq('AHA-Secret is a simple and secure way to share secrets.')
+    end
+
+    it 'returns the custom meta description' do
+      expect(html_meta_description(custom:'replace', content:'Custom Description')).to eq('Custom Description')
+    end
+
+    it 'merges the custom meta description with the default meta description' do
+      expect(html_meta_description(custom:'append', content:'Custom Description')).to eq('Custom Description, AHA-Secret is a simple and secure way to share secrets.')
+    end
+
+    it 'returns the default meta keywords' do
+      expect(html_meta_keywords(custom:false, content:nil)).to eq('secret, share, encryption, secure, simple, bin, paste, text, code')
+    end
+
+    it 'returns the custom meta keywords' do
+      expect(html_meta_keywords(custom:'replace', content:'Custom Keywords')).to eq('Custom Keywords')
+    end
+
+    it 'merges the custom meta keywords with the default meta keywords' do
+      expect(html_meta_keywords(custom:'append', content:'Custom Keywords')).to eq('Custom Keywords, secret, share, encryption, secure, simple, bin, paste, text, code')
+    end
+  end
+end


### PR DESCRIPTION
As alternative we could

1. store the original strings in config.yml - so they just need to be replaced
2. store the original strings in i18n language files - so they can be replaced there