### PR TITLE
no custom settings by default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -5,9 +5,9 @@ default: &common_settings
   default_locale: "en"
   custom:
     stylesheet: true # set to true to use custom stylesheet in public/stylesheets/custom.css
-    html_title: append # possible values: false, replace, append
+    html_title: false # possible values: false, replace, append
     html_title_string: your-custom-title-here
-    meta_description: replace # possible values: false, replace, append
+    meta_description: false # possible values: false, replace, append
     meta_description_string: your-custom-description-here
     meta_description_keywords: your, keywords, here
 


### PR DESCRIPTION
While deploying a demo instance on render.com i noticed default custom html tiltle.

With this changes, defaults are set false, no custom html title and no custom meta content will be appended.