### PR TITLE
Ruby workflow: load database from schema dump

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,7 +39,7 @@ jobs:
           RACK_ENV: test
         run: |
           bundle exec rake db:create
-          bundle exec rake db:migrate
+          bundle exec rake db:schema:load
           sqlite3 db/database/test.sqlite3 "select * from schema_migrations"
       - name: Run brakeman
         run: bundle exec brakeman

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tmp/
 db/*.sqlite*
 db/database/*.sqlite*
+db/structure.sql
 
 
 # Used by dotenv library to load environment variables.

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@
 /tmp/
 db/*.sqlite*
 db/database/*.sqlite*
-db/structure.sql
-
 
 # Used by dotenv library to load environment variables.
 .env

--- a/Rakefile
+++ b/Rakefile
@@ -43,3 +43,10 @@ task :migrateserv do
   Rake::Task['db:migrate'].invoke
   Rake::Task['serve'].invoke
 end
+
+task :after_migration_hook do
+  ENV['SCHEMA_FORMAT'] = 'sql'
+  Rake::Task['db:schema:dump'].invoke
+end
+
+Rake::Task['db:migrate'].enhance [:after_migration_hook]

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "bins" ("payload" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "id" varchar, "expire_date" datetime(6) DEFAULT (datetime('now','+7 day','localtime')), "has_password" boolean DEFAULT 0);
+CREATE UNIQUE INDEX "index_bins_on_id" ON "bins" ("id");
+INSERT INTO "schema_migrations" (version) VALUES
+('20240914195836'),
+('20240407035007'),
+('20240326191856'),
+('20240325152739'),
+('20240324133511'),
+('20240322074525');
+


### PR DESCRIPTION
When a database migration is executed, the schema dump will be updated (I think rails does this, too).

The ruby workflow loads the schema instead of executing every single migration,
therefore, the current schema is stored in repository now.