### PR TITLE
Fix broken docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM ruby:3.2
 LABEL authors="Wolfgang Hotwagner"
 
+RUN apt-get update
+
+RUN apt-get install -y sqlite3
+
+RUN apt-get clean
+
 ARG RACK_ENV=production
 
 ENV RACK_ENV=$RACK_ENV

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 ---
+version: "3"
 
 services:
   ahasecret:


### PR DESCRIPTION
This is a hotfix for the broken docker-deployment. Newer docker-compose do not work without "version 3" in the docker-compose.yml. The new update of sqlite3 won't work without sqlite3 installed.