### PR TITLE
Add tests with wrong link & password

### DIFF
--- a/spec/features/create_bin_spec.rb
+++ b/spec/features/create_bin_spec.rb
@@ -6,6 +6,17 @@ feature 'Create Bin', type: :feature, driver: :playwright do
     expect(page).to have_content 'Create another secret'
   end
 
+  scenario 'User creates a new bin and reveals with wrong link' do
+    visit '/'
+    fill_in 'bin[payload]', with: 'Hello, World!'
+    click_button 'Create Secret'
+    secret_url = find('#secret-url').value
+    visit secret_url + 'wrong'
+
+    click_button 'Reveal'
+    expect(page).to have_content 'This message was deleted from the server'
+  end
+
   scenario 'User creates and reveals a bin' do
     visit '/'
     fill_in 'bin[payload]', with: 'Hello, World!'
@@ -18,6 +29,23 @@ feature 'Create Bin', type: :feature, driver: :playwright do
     expect(decrypted_secret).to eq 'Hello, World!'
   end
 
+  scenario 'User creates a bin and reveals with wrong password' do
+    visit '/'
+    fill_in 'bin[payload]', with: 'Hello, World!'
+    check 'Set additional password'
+    fill_in 'add-password', with: 'asdf'
+    send_keys :tab
+
+    click_button 'Create Secret'
+    secret_url = find('#secret-url').value
+    visit secret_url
+
+    fill_in 'passwd', with: 'wrong'
+    send_keys :tab
+    click_button 'Unlock'
+    expect(page).to have_content 'Decryption error'
+  end
+
   scenario 'User creates and reveals a bin with password' do
     visit '/'
     fill_in 'bin[payload]', with: 'Hello, World!'
@@ -27,7 +55,6 @@ feature 'Create Bin', type: :feature, driver: :playwright do
 
     click_button 'Create Secret'
     secret_url = find('#secret-url').value
-    execute_script('console.log("' + secret_url + '")')
     visit secret_url
 
     fill_in 'passwd', with: 'asdf'


### PR DESCRIPTION
As discussed i add some tests to prove that no secret is shown, if the password is wrong.

Additionally, there is a passing test expecting an error message, if the link is not the original one.

See   [expectation](https://github.com/aha-oida/aha-secret/blob/7596c754044a0bf43f1dc3ba02f4660b7dff907c/spec/features/create_bin_spec.rb#L17) - for me the error message is okay (it does not say "wrong link").