### PR TITLE
Add working dir to pages workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build site for testing
         run: |
           cd docs
-          bundle exec jekyll build --config local_config.yml -d _testoutput
+          bundle exec jekyll build --config _local_config.yml -d _testoutput
       - name: Run htmlproofer
         run: |
           cd docs

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -40,10 +40,11 @@ jobs:
           ruby-version: '3.3.6' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+          working-directory: docs
       - name: Install dependencies
         run: |
           cd docs
-          bundle install
+          # bundle install
       - name: Build site for testing
         run: |
           cd docs
@@ -64,6 +65,7 @@ jobs:
           ruby-version: '3.3.6' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+          working-directory: docs
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Set working directory on ruby setup, so we do not need to `bundle install` additionally.

Fix call to local_config file of jekyll