### PR TITLE
Exclude dev & test env from bundle install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN bundle install
+RUN bundle install --without development test
 
 CMD ["bundle","exec","rake","migrateserv"]


### PR DESCRIPTION
In Dockerfile only production gems are installed.

## Summary by Sourcery

Build:
- Remove development and test gems from the Docker image.