### PR TITLE
Fix testing nil (id)

### DIFF
--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe Helpers, type: :helper do
     let(:request) { double('request', base_url: 'http://example.org') }
 
     it 'returns the bin retrieval url' do
-      bin = Bin.new(payload: 'Hello, World!')
+      bin = double('bin', id: 1)
       expect(bin_retrieval_url(bin)).to eq("http://example.org/bins/#{bin.id}")
     end
   end
 
   describe '#html_title' do
-    # let(:config) { double('config', custom: { title: 'Secret Bin' }) }
-
     it 'returns the default title' do
       expect(html_title(custom:false, content:nil)).to eq('aha-secret: Share Secrets')
     end


### PR DESCRIPTION
## Summary by Sourcery

Update test cases in helpers spec to improve test isolation and simplify test setup

Tests:
- Modify test for bin retrieval URL to use a double instead of creating a real Bin object
- Simplify HTML title test by removing commented-out configuration