### PR TITLE
Htmlproofer ignore gnu.org

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -50,7 +50,7 @@ jobs:
           bundle exec jekyll build --config _build_config.yml -d _testoutput
       - name: Run htmlproofer
         run: |
-          bundle exec htmlproofer ./_testoutput
+          bundle exec htmlproofer --ignore-urls  "/www.gnu.org/" ./_testoutput
   # Build job
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Checking generated links from documentation produces an error,
gnu.org seems not to be available from CI runs.

When running this test local, the link can be resolved.

## Summary by Sourcery

CI:
- Add an ignore URL flag to HTMLProofer to skip checking links to gnu.org in the GitHub Actions workflow