### PR TITLE
Add condition to markdown check for changed files

### DIFF
--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -10,6 +10,9 @@ jobs:
     outputs:
       changed: ${{ steps.check_markdown_files.outputs.changed }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Check if markdown files changed
         id: check_markdown_files
         run: |

--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -5,10 +5,20 @@ on:
     branches:
       - main
 jobs:
-  build:
-
+  condition_markdown_files:
     runs-on: ubuntu-latest
-
+    outputs:
+      changed: ${{ steps.check_markdown_files.outputs.changed }}
+    steps:
+    - name: Check if markdown files changed
+      id: check_markdown_files
+      run: |
+        git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.md$' || echo "no markdown files changed"
+        echo "changed=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.md$' || echo 'false')" >> $GITHUB_OUTPUT
+  check_links:
+    runs-on: ubuntu-latest
+    needs: condition_markdown_files
+    if: needs.condition_markdown_files.outputs.changed != 'false'
     steps:
     - uses: actions/checkout@v4
     - name: Setup Ruby

--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -10,11 +10,15 @@ jobs:
     outputs:
       changed: ${{ steps.check_markdown_files.outputs.changed }}
     steps:
-    - name: Check if markdown files changed
-      id: check_markdown_files
-      run: |
-        git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.md$' || echo "no markdown files changed"
-        echo "changed=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.md$' || echo 'false')" >> $GITHUB_OUTPUT
+      - name: Check if markdown files changed
+        id: check_markdown_files
+        run: |
+          md_files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.md$' || true)
+          if [ -n "$md_files" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
   check_links:
     runs-on: ubuntu-latest
     needs: condition_markdown_files

--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 jobs:
-  condition_markdown_files:
+  markdown_files_changed_check:
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check_markdown_files.outputs.changed }}
@@ -21,8 +21,8 @@ jobs:
           fi
   check_links:
     runs-on: ubuntu-latest
-    needs: condition_markdown_files
-    if: needs.condition_markdown_files.outputs.changed != 'false'
+    needs: markdown_files_changed_check
+    if: needs.markdown_files_changed_check.outputs.changed != 'false'
     steps:
     - uses: actions/checkout@v4
     - name: Setup Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         ruby-version: ['3.2.6', '3.4.2']
     env:
-      undercover_version: '3.4.2'
+      undercover_version: 'TEMPORARY_DISABLED'
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ For further information see the [documentation](https://aha-oida.github.io/aha-s
 # License
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
+[broken dummy link](https://doesnotexist.cc)

--- a/README.md
+++ b/README.md
@@ -38,5 +38,3 @@ For further information see the [documentation](https://aha-oida.github.io/aha-s
 # License
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-
-[broken dummy link](https://doesnotexist.cc)


### PR DESCRIPTION
## Summary by Sourcery

Modify GitHub Actions workflows to conditionally run markdown checks only when markdown files have changed

CI:
- Add a new job to check for changed markdown files before running link checks
- Conditionally run markdown link checks based on the presence of changed markdown files

Chores:
- Temporarily disable undercover version in Ruby workflow