### PR TITLE
Rspec: suppress request logs, change output format

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+--format documentation
+--color

--- a/docs/data/development/environment.md
+++ b/docs/data/development/environment.md
@@ -50,3 +50,8 @@ $ bundle exec rspec
 # OR
 $ bundle exec rake
 ```
+
+Run e2e tests with request log output:
+```
+SHOW_BROWSER=1 bundle exec rake
+```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,19 @@ RSpec.configure do |config|
 
   Capybara.current_driver = :playwright
 
-
+  unless ENV['SHOW_BROWSER']
+    original_stderr = $stderr
+    original_stdout = $stdout
+    config.before(:all) do
+      # Redirect stderr and stdout
+      $stderr = File.open(File::NULL, "w")
+      $stdout = File.open(File::NULL, "w")
+    end
+    config.after(:all) do
+      $stderr = original_stderr
+      $stdout = original_stdout
+    end
+  end
 end
 
 def app


### PR DESCRIPTION
* suppress stdout output when running tests (can be disabled with ENV var as documented)
* change rspec output to documentation format