### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdown-check.yml
+++ b/.github/workflows/markdown-check.yml
@@ -1,5 +1,8 @@
 name: Check links in markdown files
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aha-oida/aha-secret/security/code-scanning/3](https://github.com/aha-oida/aha-secret/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only reads repository contents (e.g., checking for markdown file changes and running a link checker), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary permissions and no write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Limit the workflow’s GITHUB_TOKEN permissions by adding a root-level permissions block with contents: read.