### PR TITLE
Fix rufus scheduler

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < Sinatra::Base
       I18n.locale = ENV['APP_LOCALE'] || AppConfig.default_locale || I18n.default_locale
     end
 
-    unless defined?(IRB)
+    unless ENV['SKIP_SCHEDULER'] == 'true'
       Rufus::Scheduler.s.interval AppConfig.cleanup_schedule do
         Bin.cleanup
       end

--- a/bin/console
+++ b/bin/console
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+eval 'export SKIP_SCHEDULER=true'
+
 bundle exec irb -I. -r config/environment.rb

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,7 +1,7 @@
-CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
-CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 CREATE TABLE IF NOT EXISTS "bins" ("payload" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "id" varchar, "expire_date" datetime(6) DEFAULT (datetime('now','+7 day','localtime')), "has_password" boolean DEFAULT 0);
 CREATE UNIQUE INDEX "index_bins_on_id" ON "bins" ("id");
+CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
 INSERT INTO "schema_migrations" (version) VALUES
 ('20240914195836'),
 ('20240407035007'),

--- a/spec/rufus_scheduler_spec.rb
+++ b/spec/rufus_scheduler_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Rufus::Scheduler integration' do
+  it 'does not start the scheduler when SKIP_SCHEDULER is true' do
+    expect(ENV['SKIP_SCHEDULER']).to eq('true')
+    # Optionally, check that no scheduler thread is running
+    expect(Thread.list.none? { |t| t[:rufus_scheduler] }).to be true
+  end
+
+  it 'starts the scheduler when SKIP_SCHEDULER is not set (subprocess integration test)' do
+    require 'tempfile'
+    script = <<~RUBY
+      require 'rufus-scheduler'
+      started = false
+      scheduler = Rufus::Scheduler.new
+      scheduler.every '1s' do
+        started = true
+        puts 'scheduled!'
+        exit 0
+      end
+      sleep 2
+      exit 1 unless started
+    RUBY
+    Tempfile.create(['rufus_test', '.rb']) do |file|
+      file.write(script)
+      file.flush
+      output = `SKIP_SCHEDULER= ruby #{file.path}`
+      expect(output).to include('scheduled!')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,9 @@ ENV['RACK_ENV'] = 'test'
 env_memcache = ENV['MEMCACHE'] || 'localhost:11211'
 ENV['MEMCACHE'] = env_memcache
 
+# Ensure SKIP_SCHEDULER is set to 'true' for all tests to avoid running Rufus::Scheduler
+ENV['SKIP_SCHEDULER'] = 'true'
+
 require_relative '../config/environment'
 require 'rack/test'
 require 'capybara/rspec'


### PR DESCRIPTION
The rufus scheduling was not started,
one can skip rufus by setting an env variable now.

## Summary by Sourcery

Enable Rufus scheduler to run by default, add option to skip it via SKIP_SCHEDULER environment variable, include tests for scheduler behavior, and adjust table ordering in structure.sql.

Bug Fixes:
- Restore Rufus scheduler startup by removing the IRB guard

Enhancements:
- Introduce SKIP_SCHEDULER environment variable to conditionally disable the scheduler

Tests:
- Add spec/rufus_scheduler_spec.rb to verify scheduler behavior under different SKIP_SCHEDULER settings

Chores:
- Reorder creation of schema_migrations and ar_internal_metadata tables in db/structure.sql