### PR TITLE
Fixed jekyll-configfiles

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -47,7 +47,7 @@ jobs:
           working-directory: docs
       - name: Build site for testing
         run: |
-          bundle exec jekyll build --config _build_config.yml -d _testoutput
+          bundle exec jekyll build --config _local_config.yml -d _testoutput
       - name: Run htmlproofer
         run: |
           bundle exec htmlproofer --ignore-urls  "/www.gnu.org/" ./_testoutput

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,7 @@
 # Welcome to Jekyll!
-#
+
+# !!!THIS CONFIG FILE IS FOR USE WITH GITHUB-PAGES!!!
+
 # This config file is meant for settings that affect your whole blog, values
 # which you are expected to set up once and rarely edit after that. If you find
 # yourself editing this file very often, consider using Jekyll's data files
@@ -30,8 +32,8 @@ baseurl: "/aha-secret" # the subpath of your site, e.g. /blog
 url: "https://aha-oida.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
-theme: just-the-docs
-# remote_theme: just-the-docs/just-the-docs@v0.10.0
+#theme: just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.10.0
 plugins:
   - jekyll-feed
 

--- a/docs/_local_config.yml
+++ b/docs/_local_config.yml
@@ -2,6 +2,8 @@
 # this is used in the test job of the workflow file
 # Welcome to Jekyll!
 #
+# !!!USE THIS CONFIG FILE FOR LOCAL BUILDS!!!
+#
 # This config file is meant for settings that affect your whole blog, values
 # which you are expected to set up once and rarely edit after that. If you find
 # yourself editing this file very often, consider using Jekyll's data files
@@ -32,7 +34,7 @@ description: >- # this means to ignore newlines until "baseurl:"
 # url: "https://aha-oida.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
-# theme: just-the-docs
+theme: just-the-docs
 # remote_theme: just-the-docs/just-the-docs@v0.10.0
 plugins:
   - jekyll-feed

--- a/docs/bin/run_local
+++ b/docs/bin/run_local
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-bundle exec jekyll serve --livereload --config _config.yml
+bundle exec jekyll serve --livereload --config _local_config.yml


### PR DESCRIPTION
This PR renames _build_config.yml to _local_config.yml so that it is more clear that the config_file is meant for local builds. It also enables `remote_theme` in the github-config and `theme` in _local_config.

## Summary by Sourcery

Rename local build config and adjust Jekyll theme settings for GitHub Pages and local builds

Enhancements:
- Rename docs/_build_config.yml to docs/_local_config.yml to clarify local build usage
- Add header notices in both configs to indicate intended use
- Enable remote_theme in docs/_config.yml for GitHub Pages
- Enable theme in docs/_local_config.yml for local builds