### PR TITLE
Fix broken base_url in docker installations

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -12,16 +12,16 @@ default: &common_settings
   custom:
     stylesheet: true # set to true to use custom stylesheet in public/stylesheets/custom.css
     html_title: false # possible values: false, replace, append
-    html_title_string: your-custom-title-here
+    html_title_string: Share secrets encrypted
     meta_description: false # possible values: false, replace, append
-    meta_description_string: your-custom-description-here
-    meta_description_keywords: your, keywords, here
+    meta_description_string: Share secrets encrypted
+    meta_description_keywords: Share, Secrets, Encrypted
     footer: false # possible values: false, replace, append
     footer_string: '<p>your-custom-footer-here <a href="https://example.com">Example</a></p>'
 
 production:
   <<: *common_settings
-  base_url: "https://example.com" # set to your production URL
+  # base_url: "https://example.com" # set to your production URL
   cleanup_schedule: "5m"
   custom:
     stylesheet: false


### PR DESCRIPTION
Basic docker-installations mostly just use environment-variables to configure the app. So the default config.yaml should have strong defaults that work for everybody.

This commit sets meta-data to something generic and sets base_url to '/' as it is the default.

This PR fixes #287

## Summary by Sourcery

Fix broken base_url in docker installations by strengthening default configuration values

Bug Fixes:
- Comment out the sample production base_url to allow fallback to '/'
- Update default html_title, meta_description, and keywords to generic ‘Share secrets encrypted’ values