### PR TITLE
Re-enable undercover f. ruby 3.4.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,7 +29,7 @@ jobs:
           - 11211:11211
     env:
       MEMCACHE: "localhost:11211"
-      undercover_version: 'TEMPORARY_DISABLED'
+      undercover_version: '3.4.2'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Set undercover_version to 3.4.2 in the GitHub Actions Ruby workflow