### PR TITLE
Feature/local undercover

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -44,7 +44,9 @@ PrePush:
     targets:
       - 'db:prepare'
       - 'spec'
-    command: ['bundle', 'exec', 'rake']
+    command: ['env', 'COVERAGE=true','bundle', 'exec', 'rake']
 
-
-
+  Undercover:
+    enabled: true
+    description: 'Run undercover to check coverage against main'
+    command: ['bundle', 'exec', 'undercover', '--compare', 'main']

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -38,15 +38,7 @@ PrePush:
     command: ['bundle', 'exec', 'brakeman']
     on_warn: fail
 
-  RakeTarget:
+  RakeAndUndercover:
     enabled: true
-    description: 'Run rake tasks'
-    targets:
-      - 'db:prepare'
-      - 'spec'
-    command: ['env', 'COVERAGE=true','bundle', 'exec', 'rake']
-
-  Undercover:
-    enabled: true
-    description: 'Run undercover to check coverage against main'
-    command: ['bundle', 'exec', 'undercover', '--compare', 'main']
+    description: 'Run tests with coverage and check undercover'
+    command: ['bash', '-c', 'env COVERAGE=true bundle exec rake db:prepare spec && bundle exec undercover --compare main']

--- a/Gemfile
+++ b/Gemfile
@@ -40,4 +40,5 @@ group :test do
   gem 'simplecov'
   gem 'simplecov-lcov'
   gem 'timecop'
+  gem 'undercover', '~> 0.8.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
       terminal-table (>= 1.5.1)
+    imagen (0.2.0)
+      parser (>= 2.5, != 2.5.1.1)
     iniparse (1.5.0)
     io-console (0.8.0)
     irb (1.15.2)
@@ -262,6 +264,7 @@ GEM
     ruby2_keywords (0.0.5)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
+    rugged (1.9.0)
     securerandom (0.4.1)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -303,6 +306,14 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    undercover (0.8.0)
+      base64
+      bigdecimal
+      imagen (>= 0.2.0)
+      rainbow (>= 2.1, < 4.0)
+      rugged (>= 0.27, < 1.10)
+      simplecov
+      simplecov_json_formatter
     unicode-display_width (3.1.5)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -357,6 +368,7 @@ DEPENDENCIES
   sprockets-helpers
   sqlite3 (~> 2.7)
   timecop
+  undercover (~> 0.8.0)
 
 BUNDLED WITH
    2.6.2

--- a/app/lib/app_config.rb
+++ b/app/lib/app_config.rb
@@ -25,6 +25,7 @@ require_relative 'app_config/accessors'
 class AppConfig
   extend Loader
   extend Accessors
+
   @config = nil
   # Core config keys (permitted_origins is optional)
   REQUIRED_KEYS = %w[rate_limit rate_limit_period cleanup_schedule base_url default_locale max_msg_length custom


### PR DESCRIPTION
Add undercover gem to test group (requires cmake!)

Adapt undercover config to:

* run rake (tests) with coverage
* run local undercover right after rake in one task (to guarantee order, should run after rake)

Closes #316

## Summary by Sourcery

Integrate the undercover gem into the test suite and streamline the pre-push workflow to enforce coverage checks by running rake with coverage followed by undercover comparison.

New Features:
- Add undercover gem to the test group to enable local coverage checks

Enhancements:
- Update .overcommit PrePush hook to run tests with coverage and then execute undercover comparison against the main branch in a single task

Chores:
- Add a blank line to app/lib/app_config.rb for formatting consistency