### PR TITLE
Replace backticks with exec to enable stdout logging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,12 +10,12 @@ task default: :spec
 
 desc 'Starts the thin web server through rackup.'
 task :serve do
-  `bundle exec rackup -p 9292`
+  exec 'bundle exec rackup -p 9292'
 end
 
 desc 'Starts the puma web server with rerun'
 task :rerun do
-  `bundle exec rerun --dir app,config,public -- rackup  --port=9292`
+  exec 'bundle exec rerun --dir app,config,public -- rackup  --port=9292'
 end
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
Backticks made stdout logging disappear, with `exec` e.g. the new version info is visible