### PR TITLE
Fix password pasting Bin reveal

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -259,7 +259,8 @@ function initLabelCheckboxState() {
 }
 
 document.getElementById("passwd")?.addEventListener("click", resetAlert);
-document.getElementById("passwd")?.addEventListener("keydown", enterPassword);
+document.getElementById("passwd")?.addEventListener("input", resetAlert);
+document.getElementById("passwd")?.addEventListener("input", enterPassword);
 document.getElementById("random-button")?.addEventListener("click", generateSecretCallback);
 document.getElementById("passwd")?.addEventListener("keyup", function (event) {
   event.preventDefault();
@@ -276,7 +277,7 @@ document.getElementById("random_symbol")?.addEventListener("change", entropyCall
 document.getElementById("random_numbers")?.addEventListener("change", entropyCallback);
 document.getElementById("random_capital")?.addEventListener("change", entropyCallback);
 document.getElementById("random_lower")?.addEventListener("change", entropyCallback);
-document.getElementById("add-password")?.addEventListener("keydown", changePassword);
+document.getElementById("add-password")?.addEventListener("input", changePassword);
 document.getElementById("copy-button")?.addEventListener("click", copyToClip);
 document.getElementById("copy-button-msg")?.addEventListener("click", copyMsgToClip);
 document.getElementById("copy-button")?.addEventListener("mouseout", showTooltip);

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -239,6 +239,11 @@ function enterPassword() {
   }
 }
 
+function handleRevealPasswordInput() {
+  resetAlert();
+  enterPassword();
+}
+
 function syncLabelCheckedClass(checkbox) {
   const label = checkbox.closest("label");
 
@@ -259,8 +264,7 @@ function initLabelCheckboxState() {
 }
 
 document.getElementById("passwd")?.addEventListener("click", resetAlert);
-document.getElementById("passwd")?.addEventListener("input", resetAlert);
-document.getElementById("passwd")?.addEventListener("input", enterPassword);
+document.getElementById("passwd")?.addEventListener("input", handleRevealPasswordInput);
 document.getElementById("random-button")?.addEventListener("click", generateSecretCallback);
 document.getElementById("passwd")?.addEventListener("keyup", function (event) {
   event.preventDefault();

--- a/spec/features/create_bin_spec.rb
+++ b/spec/features/create_bin_spec.rb
@@ -78,6 +78,35 @@ feature 'Create Bin', type: :feature, js: true do
     expect(decrypted_secret).to eq 'Hello, World!'
   end
 
+  scenario 'User pastes password to reveal a protected bin' do
+    visit '/'
+    fill_in 'bin[payload]', with: 'Hello, World!'
+    page.execute_script("document.getElementById('has_password').click()")
+    expect(page).to have_field('add-password', visible: true)
+    fill_in 'add-password', with: 'asdf'
+    send_keys :tab
+    click_button 'Create Secret'
+
+    secret_url = find('#secret-url').value
+    visit secret_url
+
+    page.execute_script(<<~JS)
+      const passwordField = document.getElementById('passwd');
+      passwordField.value = 'asdf';
+      passwordField.dispatchEvent(new ClipboardEvent('paste', {
+        bubbles: true,
+        clipboardData: new DataTransfer()
+      }));
+      passwordField.dispatchEvent(new Event('input', { bubbles: true }));
+    JS
+
+    expect(page).to have_button('Unlock', disabled: false)
+    click_button 'Unlock'
+
+    decrypted_secret = find('#dec-msg').value
+    expect(decrypted_secret).to eq 'Hello, World!'
+  end
+
   scenario 'User pastes content exceeding max allowed characters' do
     visit '/'
     textarea = find('textarea[name="bin[payload]"]')

--- a/spec/features/create_bin_spec.rb
+++ b/spec/features/create_bin_spec.rb
@@ -1,4 +1,26 @@
 feature 'Create Bin', type: :feature, js: true do
+  def paste_into_field(field_id, text)
+    page.execute_script(<<~JS, field_id, text)
+      ((targetFieldId, pastedText) => {
+        const field = document.getElementById(targetFieldId);
+        const clipboardData = new DataTransfer();
+        clipboardData.setData('text', pastedText);
+
+        field.focus();
+
+        const pasteEvent = new ClipboardEvent('paste', {
+          bubbles: true,
+          clipboardData
+        });
+
+        field.dispatchEvent(pasteEvent);
+
+        field.value = pastedText;
+        field.dispatchEvent(new Event('input', { bubbles: true }));
+      })(...arguments);
+    JS
+  end
+
   scenario 'User creates a bin that is exact max size chars' do
     visit '/'
     fill_in 'bin[payload]', with: SecureRandom.alphanumeric(AppConfig.max_msg_length)
@@ -90,16 +112,10 @@ feature 'Create Bin', type: :feature, js: true do
     secret_url = find('#secret-url').value
     visit secret_url
 
-    page.execute_script(<<~JS)
-      const passwordField = document.getElementById('passwd');
-      passwordField.value = 'asdf';
-      passwordField.dispatchEvent(new ClipboardEvent('paste', {
-        bubbles: true,
-        clipboardData: new DataTransfer()
-      }));
-      passwordField.dispatchEvent(new Event('input', { bubbles: true }));
-    JS
+    paste_into_field('passwd', 'asdf')
 
+    password_field = find('#passwd')
+    expect(password_field.value).to eq 'asdf'
     expect(page).to have_button('Unlock', disabled: false)
     click_button 'Unlock'
 


### PR DESCRIPTION
# Task
Fix the bug reported #469 

# Description
The password text input does not enable the reveal button on paste

# How Has This Been Tested?
Manually and with a failing test.

# Checklist

- [x] I have successfully run overcommit locally
- [x] I have added tests to cover my changes
- [x] I have linked the issue-id to the task-description
- [x] I have performed a self-review of my own code
