### PR TITLE
Optional HOST_PORT via ENV var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,12 @@ services:
       # - ./custom.css:/usr/src/app/public/stylesheets/custom.css
     ports:
       - "127.0.0.1:${HOST_PORT:-9292}:9292"
-    # RACK_ENV: production
-    # AHA_SECRET_BASE_URL: "https://please.change.me.now"
-    # AHA_SECRET_PERMITTED_ORIGINS: "https://please.change.me.now"
-    # AHA_SECRET_MEMCACHE_URL: "memcached:11211"
-    # AHA_SECRET_SESSION_SECRET: "your-secure-random-session-secret-here"
+    # environment:
+    #   RACK_ENV: production
+    #   AHA_SECRET_BASE_URL: "https://please.change.me.now"
+    #   AHA_SECRET_PERMITTED_ORIGINS: "https://please.change.me.now"
+    #   AHA_SECRET_MEMCACHE_URL: "memcached:11211"
+    #   AHA_SECRET_SESSION_SECRET: "your-secure-random-session-secret-here"
     env_file: .env
     depends_on:
       - memcached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,12 @@ services:
       # - ./config.yml:/usr/src/app/config/config.yml
       # - ./custom.css:/usr/src/app/public/stylesheets/custom.css
     ports:
-      - "127.0.0.1:9292:9292"
-    #  environment:
-       #      RACK_ENV: production
-       #      AHA_SECRET_BASE_URL: "https://please.change.me.now"
-       #      AHA_SECRET_PERMITTED_ORIGINS: "https://please.change.me.now"
-       #      AHA_SECRET_MEMCACHE_URL: "memcached:11211"
-       #      AHA_SECRET_SESSION_SECRET: "your-secure-random-session-secret-here"
+      - "127.0.0.1:${HOST_PORT:-9292}:9292"
+    # RACK_ENV: production
+    # AHA_SECRET_BASE_URL: "https://please.change.me.now"
+    # AHA_SECRET_PERMITTED_ORIGINS: "https://please.change.me.now"
+    # AHA_SECRET_MEMCACHE_URL: "memcached:11211"
+    # AHA_SECRET_SESSION_SECRET: "your-secure-random-session-secret-here"
     env_file: .env
     depends_on:
       - memcached


### PR DESCRIPTION
I want to set the port the docker container will expose.

# Task
Introduce an optional `HOST_PORT` env variable. 

# Description
Set a `HOST_PORT` env variable to let docker expose another port than the default 9292.

# How Has This Been Tested?
Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have successfully run overcommit locally
- [ ] I have added tests to cover my changes
- [ ] I have linked the issue-id to the task-description
- [x] I have performed a self-review of my own code
