### PR TITLE
Remove undercover gem and related CI configurations

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,6 @@ jobs:
           - 11211:11211
     env:
       AHA_SECRET_MEMCACHE_URL: "localhost:11211"
-      undercover_version: 'DEACTIVATED_SET_3.4.2_TO_REACTIVATE'
       RACK_ENV: test
 
     steps:
@@ -52,14 +51,7 @@ jobs:
           bundle exec overcommit --sign
       - name: Run pre-commit checks
         run: bundle exec overcommit --run pre-commit
-      - name: Run pre-push checks with coverage
-        if: ${{ matrix.ruby-version == env.undercover_version }}
-        env:
-          COVERAGE: "true"
-        run: bundle exec overcommit --run pre-push
-      # Run pre-push checks without coverage for other Ruby versions
       - name: Run pre-push checks
-        if: ${{ matrix.ruby-version != env.undercover_version }}
         run: bundle exec overcommit --run pre-push
       - name: Upload screenshots
         if: always()
@@ -69,11 +61,3 @@ jobs:
           path: tmp/capybara
           if-no-files-found: ignore
           retention-days: 7
-      # only upload coverage once
-      - name: undercover
-        if: ${{ matrix.ruby-version == env.undercover_version && github.ref_name == 'main' }}
-        run: |
-          ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
-            --repo ${{ github.repository }} \
-            --commit ${{ github.event.pull_request.head.sha || github.sha }} \
-            --lcov /home/runner/_work/aha-secret/aha-secret/coverage/lcov/aha-secret.lcov

--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,4 @@ group :test do
   gem 'simplecov'
   gem 'simplecov-lcov'
   gem 'timecop'
-  gem 'undercover', '~> 0.8.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,15 +311,6 @@ GEM
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    undercover (0.8.5)
-      base64
-      benchmark
-      bigdecimal
-      imagen (>= 0.2.0)
-      rainbow (>= 2.1, < 4.0)
-      rugged (>= 0.27, < 1.10)
-      simplecov
-      simplecov_json_formatter
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -373,7 +364,6 @@ DEPENDENCIES
   sprockets-helpers
   sqlite3 (~> 2.9)
   timecop
-  undercover (~> 0.8.5)
 
 BUNDLED WITH
   4.0.3

--- a/docs/data/configuration.md
+++ b/docs/data/configuration.md
@@ -83,7 +83,6 @@ The following environment variables can be used to configure **aha-secret**. Mos
 | `COVERAGE` | Enable code coverage (SimpleCov) | *(none)* | *(none)* | [OPTIONAL] Used in test/CI |
 | `CI` | Set automatically in CI | *(none)* | *(none)* | [OPTIONAL] Used to enable CI-specific logic |
 | `SHOW_BROWSER` | Show browser in e2e tests | *(none)* | *(none)* | [OPTIONAL] Set to `true` to see browser window |
-| `undercover_version` | Used in CI for coverage matrix | *(none)* | *(none)* | [OPTIONAL] |
 
 ### Removed Legacy Variables
 
@@ -193,7 +192,7 @@ permitted_origins: "https://example.com,https://www.example.com"
 ### Test/CI-Specific Variables
 
 - `SKIP_SCHEDULER` is set to `true` in test/CI to disable background jobs.
-- `COVERAGE`, `CI`, `SHOW_BROWSER` and `undercover_version` are used for test and CI configuration.
+- `COVERAGE`, `CI`, and `SHOW_BROWSER` are used for test and CI configuration.
 
 ### Disabling Background Jobs
 


### PR DESCRIPTION
# Task
Currently undercover is unused. Therefore we want to remove it.

Closes #462 

# Description
Remove the gem file and all parts of the CI config, where undercover was involved.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
Ran tests locally

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have successfully run overcommit locally
- [ ] I have added tests to cover my changes
- [x] I have linked the issue-id to the task-description
- [x] I have performed a self-review of my own code
