### PR TITLE
Isolate AppConfig specs from host env overrides

### DIFF
--- a/spec/lib/app_config_spec.rb
+++ b/spec/lib/app_config_spec.rb
@@ -4,14 +4,10 @@ require 'spec_helper'
 require_relative '../../app/lib/app_config'
 
 RSpec.describe AppConfig do
-  ISOLATED_ENV_KEYS = %w[
-    AHA_SECRET_PERMITTED_ORIGINS
-    PERMITTED_ORIGINS
-    AHA_SECRET_URL
-    URL
-    AHA_SECRET_APP_LOCALE
-    APP_LOCALE
-  ].freeze
+  ISOLATED_ENV_KEYS = (
+    (AppConfig::REQUIRED_KEYS + AppConfig::OPTIONAL_KEYS).map { |key| "AHA_SECRET_#{key.upcase}" } +
+    AppConfig::Loader::LEGACY_ENV_MAPPINGS.keys
+  ).freeze
 
   # Save and restore ENV for tests that modify ENV
   around do |example|

--- a/spec/lib/app_config_spec.rb
+++ b/spec/lib/app_config_spec.rb
@@ -4,10 +4,20 @@ require 'spec_helper'
 require_relative '../../app/lib/app_config'
 
 RSpec.describe AppConfig do
+  ISOLATED_ENV_KEYS = %w[
+    AHA_SECRET_PERMITTED_ORIGINS
+    PERMITTED_ORIGINS
+    AHA_SECRET_URL
+    URL
+    AHA_SECRET_APP_LOCALE
+    APP_LOCALE
+  ].freeze
+
   # Save and restore ENV for tests that modify ENV
   around do |example|
     original_env = ENV.to_hash.dup
     begin
+      ISOLATED_ENV_KEYS.each { |key| ENV.delete(key) }
       example.run
     ensure
       ENV.replace(original_env)


### PR DESCRIPTION
# Task
<!-- Please add link a relevant issue or task -->
Better isolation in tests

# Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Multiple times it happened that tests went red because i had some local ENV stuff exported.
Therefore i tried to isolate the tested variables.

# How Has This Been Tested?
<!-- Please describe how you tested your changes -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have successfully run overcommit locally
- [ ] I have added tests to cover my changes
- [ ] I have linked the issue-id to the task-description
- [ ] I have performed a self-review of my own code
