### PR TITLE
Fix Docker startup with fresh database

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,20 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx for multi-platform builds
         uses: docker/setup-buildx-action@v2
+      - name: Build Docker image for smoke test
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          load: true
+          tags: aha-secret:smoke-test
+      - name: Smoke test Docker image with a fresh database
+        env:
+          AHA_SECRET_IMAGE: aha-secret:smoke-test
+        run: |
+          touch .env
+          docker pull memcached:latest
+          docker compose up --pull=never --wait-timeout=30 --wait
+
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -62,4 +76,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ ENV['RACK_ENV'] ||= 'development'
 ENV['RUNNING_RAKE'] = 'true'
 
 require_relative 'config/environment'
-require 'rspec/core/rake_task'
 require 'sequel'
 require 'sequel/extensions/migration'
 
@@ -20,7 +19,12 @@ task :rerun do
   exec 'bundle exec rerun --dir app,config,public -- rackup  --port=9292'
 end
 
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError => e
+  raise unless e.path == 'rspec/core/rake_task'
+end
 
 desc 'Load the application environment'
 task :environment do

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -18,7 +18,7 @@ require_relative 'initializers/migration_check'
 rake_app = defined?(Rake.application) ? Rake.application : nil
 rake_tasks = rake_app.respond_to?(:top_level_tasks) ? rake_app.top_level_tasks : []
 running_rake = rake_tasks.any?
-running_db_task = rake_tasks.any? { |task| task.start_with?('db:') }
+running_db_task = rake_tasks.any? { |task| task == 'migrateserv' || task.start_with?('db:') }
 running_tests = ENV['RACK_ENV'] == 'test'
 
 # Check for pending migrations before loading models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ahasecret:
     # build: .
-    image: ghcr.io/aha-oida/aha-secret:latest
+    image: ${AHA_SECRET_IMAGE:-ghcr.io/aha-oida/aha-secret:latest}
     volumes:
       - ahadb:/usr/src/app/db/database
       # - ./config.yml:/usr/src/app/config/config.yml


### PR DESCRIPTION
# Task

Fix Docker image startup when using a fresh database volume.
Fixes #499

# Description

The Docker image failed before migrations could run because `migrateserv` loaded application models while the `bins` table did not yet exist.

This change:

- Treats `migrateserv` as a database task so migrations run before models load.
- Loads the RSpec Rake task only when RSpec is installed.
- Allows Docker Compose to use a locally built image through `AHA_SECRET_IMAGE`.
- Adds a Compose-based fresh-volume smoke test before publishing the release image.

# How Has This Been Tested?

- Built the production Docker image without development and test gems.
- Started the image through Docker Compose with a fresh named database volume.
- Confirmed both Compose services reached their ready state.
- Confirmed the application returned HTTP 200.
- Ran 130 non-browser RSpec examples with 0 failures.
- Ran RuboCop with no offenses.
- Ran Brakeman with no security warnings.
- Validated Ruby and GitHub Actions workflow syntax.

The browser feature suite was not rerun because this change does not affect the UI or browser behavior.

# Checklist

- [x] I have successfully run overcommit locally
- [x] I have added tests to cover my changes
- [x] I have linked the issue-id to the task-description
- [x] I have performed a self-review of my own code