### PR TITLE
Docs: Fix link color in footer bottom left

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -19,7 +19,7 @@
   color: $sidebar-footer-color;
 }
 
-a.site-footer {
+.site-footer a {
   color: $sidebar-footer-link-color;
 }
 


### PR DESCRIPTION
# Task

<img width="394" height="149" alt="image" src="https://github.com/user-attachments/assets/fd6cc088-e3ac-4f3b-acc2-d9d54bbef296" />

Currently, the link in the footer is dark on dark. This PR changes the link color to white.

<img width="394" height="149" alt="image" src="https://github.com/user-attachments/assets/d2226e21-8ba7-4ce8-8d5b-7cf4e5881adb" />
